### PR TITLE
feat: マイページとトップページを連携

### DIFF
--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -56,12 +56,12 @@
                                 <div id="settingsDropdown" class="absolute right-0 top-full mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 hidden z-50">
                                     <div class="py-1">
                                         <!-- マイページ -->
-                                        <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100 transition duration-200">
-                                            <svg class="h-4 w-4 mr-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
-                                            </svg>
-                                            マイページ
-                                        </a>
+                                        <%= link_to mypage_path, class: "flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100 transition duration-200" do %>
+                                          <svg class="h-4 w-4 mr-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+                                          </svg>
+                                          マイページ
+                                        <% end %>
                                         
                                         <!-- 履歴 -->
                                         <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100 transition duration-200">

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -63,6 +63,12 @@
                 <span class="block text-3xl mb-2">🚪</span>
                 ログアウト
             </a>
+
+            <!-- トップページに戻る -->
+            <%= link_to root_path, class: "block p-6 m-4 bg-gradient-to-r from-gray-500 to-gray-600 text-white text-center font-bold text-lg rounded-xl shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-300" do %>
+                <span class="block text-3xl mb-2">🏠</span>
+                トップページに戻る
+            <% end %>
         </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,6 @@
 # config/routes.rb
 Rails.application.routes.draw do
   root to: "home#top"
-  get 'login', to: 'sessions#new'
-  post 'login', to: 'sessions#create'
-  delete 'logout', to: 'sessions#destroy'
   get "/mypage", to: "users#mypage"
 
   resources :products do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 # config/routes.rb
 Rails.application.routes.draw do
   root to: "home#top"
-
+  get 'login', to: 'sessions#new'
+  post 'login', to: 'sessions#create'
+  delete 'logout', to: 'sessions#destroy'
   get "/mypage", to: "users#mypage"
-  get "logins/new", to: "logins#new"
 
   resources :products do
     member do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,7 +92,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_01_143822) do
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name", null: false
     t.string "email", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -100,6 +99,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_01_143822) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name", null: false
     t.string "phone"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name"


### PR DESCRIPTION
### 実装内容
トップページとマイページを連携

### スクリーンショット
<img width="1025" height="486" alt="スクリーンショット 2025-08-08 1 02 54" src="https://github.com/user-attachments/assets/1051305b-f135-4668-a3c5-1f478be49c2d" />

<img width="866" height="539" alt="スクリーンショット 2025-08-08 1 03 39" src="https://github.com/user-attachments/assets/b0e6ab6b-dabd-4994-a37f-1dd6918868d3" />

### gemfile の変更

- [x] なし

### 動作確認項目
トップページ / マイページ　〜　マイページ / トップページに戻る　動作確認

### 補足事項
なし